### PR TITLE
UnmarshalText for JSON map keys

### DIFF
--- a/ft.go
+++ b/ft.go
@@ -73,13 +73,19 @@ func (fs *String) UnmarshalJSON(bArr []byte) (err error) {
 	return
 }
 
-// MarshalText must be implemented for custom types to be used as JSON map keys
-// https://stackoverflow.com/a/52161688/639133
+// TextMarshaler and TextUnmarshaler interfaces
+// must be implemented for custom types to be used as JSON map keys
+// https://pkg.go.dev/encoding#TextMarshaler
+
 func (fs String) MarshalText() (text []byte, err error) {
 	if !fs.Valid {
 		return text, errors.Errorf("invalid ft.String")
 	}
 	return []byte(fs.String), nil
+}
+
+func (fs *String) UnmarshalText(text []byte) error {
+	return fs.UnmarshalJSON(text)
 }
 
 // Int can be used to decode any JSON value to int64.
@@ -151,6 +157,10 @@ func (fi Int) MarshalText() (text []byte, err error) {
 	return []byte(strconv.FormatInt(fi.Int64, 10)), nil
 }
 
+func (fi *Int) UnmarshalText(text []byte) error {
+	return fi.UnmarshalJSON(text)
+}
+
 // Float can be used to decode any JSON value to int64.
 // Strings that are not valid representation of a number will error.
 // Boolean values will error
@@ -218,6 +228,10 @@ func (ff Float) MarshalText() (text []byte, err error) {
 		return text, errors.Errorf("invalid ft.Float")
 	}
 	return []byte(strconv.FormatFloat(ff.Float64, 'f', -1, 64)), nil
+}
+
+func (ff *Float) UnmarshalText(text []byte) error {
+	return ff.UnmarshalJSON(text)
 }
 
 // Bool can be used to decode any JSON value to bool.
@@ -296,4 +310,8 @@ func (fb Bool) MarshalText() (text []byte, err error) {
 		return text, errors.Errorf("invalid ft.Bool")
 	}
 	return []byte(strconv.FormatBool(fb.Bool)), nil
+}
+
+func (fb *Bool) UnmarshalText(text []byte) error {
+	return fb.UnmarshalJSON(text)
 }

--- a/ft_test.go
+++ b/ft_test.go
@@ -429,10 +429,14 @@ func TestMapKeys(t *testing.T) {
 	is.Equal(
 		string(b),
 		`{"String":"foo","Int":123,"Bool":false,"Float":1.618}`,
-	) // Invalid values are marshalled to JSON
+	) // Invalid values are marshalled to JSON as is
 
 	b = []byte(`{"StringMap":{"foo":true},"IntMap":{"123":true},"BoolMap":{"true":true},"FloatMap":{"1.618":true}}`)
 	d = data{}
 	err = json.Unmarshal(b, &d)
 	is.NoErr(err)
+
+	compare, err := json.Marshal(d)
+	is.NoErr(err)
+	is.Equal(string(b), string(compare)) // Unmarshal and Marshal doesn't match
 }

--- a/ft_test.go
+++ b/ft_test.go
@@ -430,4 +430,9 @@ func TestMapKeys(t *testing.T) {
 		string(b),
 		`{"String":"foo","Int":123,"Bool":false,"Float":1.618}`,
 	) // Invalid values are marshalled to JSON
+
+	b = []byte(`{"StringMap":{"foo":true},"IntMap":{"123":true},"BoolMap":{"true":true},"FloatMap":{"1.618":true}}`)
+	d = data{}
+	err = json.Unmarshal(b, &d)
+	is.NoErr(err)
 }

--- a/ftnull.go
+++ b/ftnull.go
@@ -84,13 +84,20 @@ func (fs *NString) UnmarshalJSON(bArr []byte) (err error) {
 	return
 }
 
-// MarshalText must be implemented for custom types to be used as JSON map keys
-// https://stackoverflow.com/a/52161688/639133
+// TextMarshaler and TextUnmarshaler interfaces
+// must be implemented for custom types to be used as JSON map keys
+// https://pkg.go.dev/encoding#TextMarshaler
+
 func (fs NString) MarshalText() (text []byte, err error) {
 	if !fs.Valid {
+		// TODO Consider marshalling as empty value instead?
 		return text, errors.Errorf("invalid ft.NString")
 	}
 	return []byte(fs.String), nil
+}
+
+func (fs *NString) UnmarshalText(text []byte) error {
+	return fs.UnmarshalJSON(text)
 }
 
 // NInt can be used to decode any JSON value to int64.
@@ -173,6 +180,10 @@ func (fi NInt) MarshalText() (text []byte, err error) {
 	return []byte(strconv.FormatInt(fi.Int64, 10)), nil
 }
 
+func (fi *NInt) UnmarshalText(text []byte) error {
+	return fi.UnmarshalJSON(text)
+}
+
 // NFloat can be used to decode any JSON value to int64.
 // Strings that are not valid representation of a number will error.
 // Boolean values will error
@@ -237,6 +248,10 @@ func (ff NFloat) MarshalText() (text []byte, err error) {
 		return text, errors.Errorf("invalid ft.NFloat")
 	}
 	return []byte(strconv.FormatFloat(ff.Float64, 'f', -1, 64)), nil
+}
+
+func (ff *NFloat) UnmarshalText(text []byte) error {
+	return ff.UnmarshalJSON(text)
 }
 
 // NBool can be used to decode any JSON value to bool.
@@ -315,4 +330,8 @@ func (fb NBool) MarshalText() (text []byte, err error) {
 		return text, errors.Errorf("invalid ft.NBool")
 	}
 	return []byte(strconv.FormatBool(fb.Bool)), nil
+}
+
+func (fb *NBool) UnmarshalText(text []byte) error {
+	return fb.UnmarshalJSON(text)
 }

--- a/ftnull_test.go
+++ b/ftnull_test.go
@@ -564,8 +564,35 @@ func TestNMapKeys(t *testing.T) {
 	is.Equal(err.Error(),
 		wrap("NBool", "invalid ft.NBool")) // Map keys must be valid
 
+	type data2 struct {
+		String ft.NString
+		Int    ft.NInt
+		Bool   ft.NBool
+		Float  ft.NFloat
+	}
+	d2 := data2{
+		String: ft.NString{
+			NullString: sql.NullString{String: "foo", Valid: false}},
+		Int: ft.NInt{
+			NullInt64: sql.NullInt64{Int64: 123, Valid: false}},
+		Bool: ft.NBool{
+			NullBool: sql.NullBool{Bool: false, Valid: false}},
+		Float: ft.NFloat{
+			NullFloat64: sql.NullFloat64{Float64: 1.618, Valid: false}},
+	}
+	b, err = json.Marshal(d2)
+	is.NoErr(err)
+	is.Equal(
+		string(b),
+		`{"String":null,"Int":null,"Bool":null,"Float":null}`,
+	) // Invalid values are marshalled to JSON as null
+
 	b = []byte(`{"StringMap":{"foo":true},"IntMap":{"123":true},"BoolMap":{"true":true},"FloatMap":{"1.618":true}}`)
 	d = data{}
 	err = json.Unmarshal(b, &d)
 	is.NoErr(err)
+
+	compare, err := json.Marshal(d)
+	is.NoErr(err)
+	is.Equal(string(b), string(compare)) // Unmarshal and Marshal doesn't match
 }

--- a/ftnull_test.go
+++ b/ftnull_test.go
@@ -563,4 +563,9 @@ func TestNMapKeys(t *testing.T) {
 	_, err = json.Marshal(d)
 	is.Equal(err.Error(),
 		wrap("NBool", "invalid ft.NBool")) // Map keys must be valid
+
+	b = []byte(`{"StringMap":{"foo":true},"IntMap":{"123":true},"BoolMap":{"true":true},"FloatMap":{"1.618":true}}`)
+	d = data{}
+	err = json.Unmarshal(b, &d)
+	is.NoErr(err)
 }


### PR DESCRIPTION
Implement `TextUnmarshaler ` interface as per [encoding.TextMarshaler](https://golang.org/pkg/encoding/#TextMarshaler), see [this stackoverflow post](https://stackoverflow.com/a/52161688/639133)

`TextMarshaler ` already implemented in https://github.com/mozey/ft/commit/076fc463c2cc5d169f28bd370522c1017ec782ce